### PR TITLE
Fix unknown color (Alpha), optimized get_gcolor_text using an array.

### DIFF
--- a/src/gbitmap_color_palette_manipulator.h
+++ b/src/gbitmap_color_palette_manipulator.h
@@ -2,7 +2,7 @@
 
 #ifdef PBL_COLOR
 char* get_gbitmapformat_text(GBitmapFormat format);
-char* get_gcolor_text(GColor m_color);
+const char* get_gcolor_text(GColor m_color);
 void replace_gbitmap_color(GColor color_to_replace, GColor replace_with_color, GBitmap *im, BitmapLayer *bml);
 void spit_gbitmap_color_palette(GBitmap *im);
 bool gbitmap_color_palette_contains_color(GColor m_color, GBitmap *im);

--- a/src/palette_tester.c
+++ b/src/palette_tester.c
@@ -1,5 +1,5 @@
 
-#include <gbitmap_color_palette_manipulator.h>
+#include "gbitmap_color_palette_manipulator.h"
 
 static Window *window = NULL;
 static BitmapLayer *b_layer = NULL;


### PR DESCRIPTION
Known issues:
1. GColorBlack, GColorClear currently treated as same in replace_gbitmap_color
2. Didn't update gbitmap_fill_all_except
3. gbitmap_fill_all_except should probably skip GColorClear.
